### PR TITLE
Add window icon on non-Windows platform

### DIFF
--- a/src/FileFunctions.cpp
+++ b/src/FileFunctions.cpp
@@ -454,6 +454,11 @@ string GetCommonResourcesFilePath()
     return commonAppDataPath + "common.dat";
 }
 
+string GetWindowIconFilePath()
+{
+    return commonAppDataPath + "mli.png";
+}
+
 #ifdef __OSX
 string GetPropertyListPath()
 {

--- a/src/FileFunctions.h
+++ b/src/FileFunctions.h
@@ -60,6 +60,8 @@ string GetFileNameFromFilePath(const string &path);
 
 string GetCommonResourcesFilePath();
 
+string GetWindowIconFilePath();
+
 #ifdef __OSX
 string GetPropertyListPath();
 #endif

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -202,8 +202,8 @@ bool Game::CreateAndInit()
         return false;
     }
 
-#ifdef __WINDOWS
 #ifndef LAUNCHER
+#ifdef __WINDOWS
     // Load and set the window icon - this is needed on Windows,
     // since just having the icon in the .exe doesn't set it for things like
     // the Alt+Tab menu.
@@ -228,6 +228,16 @@ bool Game::CreateAndInit()
             SendMessage(hwnd, WM_SETICON, ICON_BIG, reinterpret_cast<WPARAM>(hBigIcon));
         }
     }
+#else
+    SDL_Surface* pIcon = IMG_Load(GetWindowIconFilePath().c_str());
+
+    if (pIcon)
+    {
+		SDL_SetWindowIcon(gpWindow, pIcon);
+    }
+
+	SDL_FreeSurface(pIcon);
+    pIcon = NULL;
 #endif
 #endif
 


### PR DESCRIPTION
I noticed that the icon is set only on Windows so I fixed that using SDL. As SDL2_image fails to load the ico (certainly because it doesn't know wich image in it to load) I just used a png. If the loading fails, it will fallback to the default icon. I let you choose wether to keep this on Windows as well or not but IMO, the lesser platform-specific, the better.
