### PR TITLE
Use @rpath for SDL frameworks

### DIFF
--- a/MyLittleInvestigations.cbp
+++ b/MyLittleInvestigations.cbp
@@ -91,6 +91,7 @@
 					<Add option="-lswscale" />
 					<Add option="-lcryptopp" />
 					<Add option="-Wl,-rpath,@loader_path/../Frameworks" />
+					<Add option="-Wl,-rpath,@executable_path/../Frameworks" />
 					<Add directory="osx" />
 				</Linker>
 			</Target>
@@ -120,13 +121,11 @@
 					<Add option="-lavutil" />
 					<Add option="-lswscale" />
 					<Add option="-lcryptopp" />
+					<Add option="-Wl,-rpath,@loader_path/../Frameworks" />
+					<Add option="-Wl,-rpath,@executable_path/../Frameworks" />
 					<Add directory="osx" />
 				</Linker>
 				<ExtraCommands>
-					<Add after="install_name_tool -change @rpath/SDL2.framework/Versions/A/SDL2 @loader_path/../Frameworks/SDL2.framework/Versions/A/SDL2 bin/Release/osx/MyLittleInvestigations" />
-					<Add after="install_name_tool -change @rpath/SDL2_image.framework/Versions/A/SDL2_image @loader_path/../Frameworks/SDL2_image.framework/Versions/A/SDL2_image bin/Release/osx/MyLittleInvestigations" />
-					<Add after="install_name_tool -change @rpath/SDL2_mixer.framework/Versions/A/SDL2_mixer @loader_path/../Frameworks/SDL2_mixer.framework/Versions/A/SDL2_mixer bin/Release/osx/MyLittleInvestigations" />
-					<Add after="install_name_tool -change @rpath/SDL2_ttf.framework/Versions/A/SDL2_ttf @loader_path/../Frameworks/SDL2_ttf.framework/Versions/A/SDL2_ttf bin/Release/osx/MyLittleInvestigations" />
 					<Add after="install_name_tool -change /usr/local/opt/ffmpeg/lib/libavcodec.57.dylib @loader_path/../Frameworks/libavcodec.dylib bin/Release/osx/MyLittleInvestigations" />
 					<Add after="install_name_tool -change /usr/local/opt/ffmpeg/lib/libavformat.57.dylib @loader_path/../Frameworks/libavformat.dylib bin/Release/osx/MyLittleInvestigations" />
 					<Add after="install_name_tool -change /usr/local/opt/ffmpeg/lib/libavutil.55.dylib @loader_path/../Frameworks/libavutil.dylib bin/Release/osx/MyLittleInvestigations" />

--- a/MyLittleInvestigationsLauncher.cbp
+++ b/MyLittleInvestigationsLauncher.cbp
@@ -71,6 +71,7 @@
 					<Add option="-lcryptopp" />
 					<Add option="-lcurl" />
 					<Add option="-Wl,-rpath,@loader_path/../Frameworks" />
+					<Add option="-Wl,-rpath,@executable_path/../Frameworks" />
 					<Add directory="osx" />
 				</Linker>
 			</Target>
@@ -94,6 +95,7 @@
 					<Add option="-lcryptopp" />
 					<Add option="-lcurl" />
 					<Add option="-Wl,-rpath,@loader_path/../Frameworks" />
+					<Add option="-Wl,-rpath,@executable_path/../Frameworks" />
 					<Add directory="osx" />
 				</Linker>
 			</Target>

--- a/MyLittleInvestigationsUpdater.cbp
+++ b/MyLittleInvestigationsUpdater.cbp
@@ -79,6 +79,7 @@
 					<Add option="-lcryptopp" />
 					<Add option="-lcurl" />
 					<Add option="-Wl,-rpath,@loader_path/../Frameworks" />
+					<Add option="-Wl,-rpath,@executable_path/../Frameworks" />
 					<Add directory="osx" />
 				</Linker>
 			</Target>
@@ -105,6 +106,7 @@
 					<Add option="-lcryptopp" />
 					<Add option="-lcurl" />
 					<Add option="-Wl,-rpath,@loader_path/../Frameworks" />
+					<Add option="-Wl,-rpath,@executable_path/../Frameworks" />
 					<Add directory="osx" />
 				</Linker>
 			</Target>


### PR DESCRIPTION
This adds `@executable_path/../Frameworks` to the list of rpaths.
Don't change the install name of the SDL frameworks: they are already rpaths.