### PR TITLE
circonvent a crash that happen a character goes OOB

### DIFF
--- a/src/CaseContent/FieldCharacter.cpp
+++ b/src/CaseContent/FieldCharacter.cpp
@@ -388,7 +388,11 @@ void FieldCharacter::Draw()
 
 void FieldCharacter::Draw(Vector2 offsetVector)
 {
-    pCurrentAnimation->Draw(GetPosition() - offsetVector - Vector2(0, extraHeight), GetDirection() == CharacterDirectionRight, 1.0);
+    if (pCurrentAnimation!=NULL) {
+        pCurrentAnimation->Draw(GetPosition() - offsetVector - Vector2(0, extraHeight), GetDirection() == CharacterDirectionRight, 1.0);
+    } else {
+        std::cerr << "FieldCharacter::Draw(Vector2 offsetVector) : pCurrentAnimation is NULL\n";
+    };
 }
 
 void FieldCharacter::Reset()


### PR DESCRIPTION
I found a crash that happen on linux. Haven't tested on windows, but this doesn't seem to be platform specific. (can't reproduce on Wine, but that's because it have the problem that I need to keep the mouse button pressed for the main character to move). This doesn't actually solve the issue, just prevent the game to crash by adding a check for a null pointer (result in the PC to be invisible when it would have crashed). (here is a video that illustrate first the crash, and second the "fixed" version). https://youtu.be/7YgTYdARBN8